### PR TITLE
bot answered a review source question wrong, added the answer to FAQ

### DIFF
--- a/docusaurus/docs/overview/getting-started.mdx
+++ b/docusaurus/docs/overview/getting-started.mdx
@@ -160,3 +160,9 @@ The Email Builder is a feature exclusive to Premium edition that allows you to e
 
 With Premium edition, you can use AI to automatically generate personalized responses to customer reviews. The AI takes into account the content of the review, your business information, and best practices for review management to create appropriate responses that you can edit before posting.
 </details>
+
+<details>
+<summary>Can I add additional review sources to Reputation Management so I can monitor them?</summary>
+
+Our development team is open to suggestions for adding new review sources to Reputation Management. To ensure the quality and reliability of these sources, they must undergo a vetting process. If you have specific review sources you'd like to see integrated into Reputation Management you can forward your recommendations to your dedicated account manager or submit them through roadmap.vendasta.com.
+</details>


### PR DESCRIPTION
The bot answered a question about adding listing sources to Repman incorrectly. Added the answer to the FAQ based on the in-platform product FAQ